### PR TITLE
Update to libxmljs v0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "glob": "^7.0.3",
-    "libxmljs": "^0.17.1",
+    "libxmljs": "^0.18.0",
     "lodash": "^4.11",
     "request-promise": "^2.0.1",
     "semver": "^5.1.0",


### PR DESCRIPTION
[libxmljs#0.18.0](https://github.com/libxmljs/libxmljs/releases/tag/v0.18.0) was released to fix some issues with building the native bindings on OS X.
